### PR TITLE
fix Error: Cannot find module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/index');


### PR DESCRIPTION
Thanks for creating the library, good stuff. I got the error below when trying to import the library. It was looking for index.js in the root directory. This change fixed it. Alternatively, changing `"main": "index.js",` to `"main": "dist/index.js",` in package.json fixes it too.

```
require('trigram-similarity')
Uncaught:
Error: Cannot find module 'node_modules/trigram-similarity/index.js'. Please verify that the package.json has a valid "main" entry
```